### PR TITLE
Enabled to acceess login page

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -38,8 +38,7 @@ class App extends StatelessWidget {
       case UserState.waiting:
         return SplashPage();
       case UserState.signedOut:
-        // return SignInPage(); ログイン機能未実装の間はコメントアウト
-        return TopPage();
+        return SignInPage();
       case UserState.signedIn:
         return TopPage();
       default:


### PR DESCRIPTION
単に開発前、ログインページがなかったときに、コメントアウトしていた、`lib/app.dart` で、ユーザーの認証状態が `signedOut` であるときに `SignInPage` にナビゲートできるように、`case UserState.signedOut:` の下の1行を書き換えました。

対応する Issue
#20 