### PR TITLE
Feature/#29 recipe search page

### DIFF
--- a/lib/presentation/search/search_model.dart
+++ b/lib/presentation/search/search_model.dart
@@ -5,10 +5,9 @@ import 'package:recipe/domain/recipe.dart';
 import 'package:recipe/presentation/signin/signin_page.dart';
 
 class SearchModel extends ChangeNotifier {
-  FirebaseAuth auth = FirebaseAuth.instance;
+  FirebaseAuth _auth = FirebaseAuth.instance;
   String userId = '';
   bool isLoading;
-  int recipeTabIndex = 0;
   List myRecipes = [];
   List publicRecipes = [];
   int loadLimit = 10;
@@ -22,7 +21,7 @@ class SearchModel extends ChangeNotifier {
   Future fetchRecipes(context) async {
     startLoading();
 
-    if (auth == null) {
+    if (_auth.currentUser == null) {
       // ユーザーが見つからない場合は pushReplacement() でログインページへ
       await Navigator.pushReplacement(
         context,
@@ -31,14 +30,14 @@ class SearchModel extends ChangeNotifier {
         ),
       );
     } else {
-      this.userId = auth.currentUser.uid;
+      this.userId = _auth.currentUser.uid;
     }
 
     /// わたしのレシピ
     // わたしのレシピを10件取得
     QuerySnapshot docsMyRecipe = await FirebaseFirestore.instance
         .collection('users/${this.userId}/recipes')
-        .orderBy('createdAt')
+        .orderBy('createdAt', descending: true)
         .limit(this.loadLimit)
         .get();
 
@@ -66,7 +65,7 @@ class SearchModel extends ChangeNotifier {
     // みんなのレシピを10件取得
     QuerySnapshot docsPublicRecipe = await FirebaseFirestore.instance
         .collection('public_recipes')
-        .orderBy('createdAt')
+        .orderBy('createdAt', descending: true)
         .limit(this.loadLimit)
         .get();
 
@@ -102,7 +101,7 @@ class SearchModel extends ChangeNotifier {
   Future fetchMoreMyRecipes() async {
     QuerySnapshot docsMyRecipe = await FirebaseFirestore.instance
         .collection('users/${this.userId}/recipes')
-        .orderBy('createdAt')
+        .orderBy('createdAt', descending: true)
         .startAfterDocument(this.myLastVisible)
         .limit(this.loadLimit)
         .get();
@@ -133,7 +132,7 @@ class SearchModel extends ChangeNotifier {
   Future fetchMorePublicRecipes() async {
     QuerySnapshot docsPublicRecipe = await FirebaseFirestore.instance
         .collection('public_recipes')
-        .orderBy('createdAt')
+        .orderBy('createdAt', descending: true)
         .startAfterDocument(this.publicLastVisible)
         .limit(this.loadLimit)
         .get();
@@ -161,11 +160,6 @@ class SearchModel extends ChangeNotifier {
       this.publicRecipes.addAll(publicRecipes);
     }
 
-    notifyListeners();
-  }
-
-  void onRecipeTabTapped(int index) {
-    this.recipeTabIndex = index;
     notifyListeners();
   }
 

--- a/lib/presentation/search/search_page.dart
+++ b/lib/presentation/search/search_page.dart
@@ -37,13 +37,14 @@ class SearchPage extends StatelessWidget {
                   body: TabBarView(
                     children: [
                       ListView(
-                        key: PageStorageKey(0),
+                        key: PageStorageKey(0), // スクロール位置の保存に必要
                         children: [
                           Padding(
                             padding: const EdgeInsets.only(
                               top: 16.0,
                               left: 8.0,
                               right: 8.0,
+                              bottom: 16.0,
                             ),
                             child: TextField(
                               onChanged: (text) {},
@@ -78,11 +79,15 @@ class SearchPage extends StatelessWidget {
                         ],
                       ),
                       ListView(
-                        key: PageStorageKey(1),
+                        key: PageStorageKey(1), // スクロール位置の保存に必要
                         children: [
                           Padding(
                             padding: const EdgeInsets.only(
-                                top: 16.0, left: 8.0, right: 8.0),
+                              top: 16.0,
+                              left: 8.0,
+                              right: 8.0,
+                              bottom: 16.0,
+                            ),
                             child: TextField(
                               onChanged: (text) {},
                               maxLines: 1,
@@ -140,6 +145,14 @@ class SearchPage extends StatelessWidget {
       // Card ウィジェットをループの個数だけリストに追加する
       list.add(
         Card(
+          elevation: 0.0,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(5.0),
+            side: BorderSide(
+              color: Color(0xFFDADADA),
+              width: 1.0,
+            ),
+          ),
           child: Padding(
             padding: const EdgeInsets.all(16.0),
             child: Row(


### PR DESCRIPTION
小刻みなPRになってしまっていますが、

* Card UI の枠線と影の調整
* @daigo-program から指摘があった、レシピの表示順序の変更（`created At` の降順にしました）
* 横スクロールで「私のレシピ」「みんなのレシピ」を移動できるように、`DefaultTabController()` による記述に変更

などが変更されています。

次は、Firestore だけでの全文検索がどの程度できるか、試しに実装してみます！